### PR TITLE
the hubot replies today's seminar info.

### DIFF
--- a/scripts/seminar_info.coffee
+++ b/scripts/seminar_info.coffee
@@ -1,0 +1,32 @@
+# Descripion:
+#   show today's seminar information
+#
+# Commands:
+#   hubot Seminar
+
+https = require "https"
+url = "https://script.google.com/macros/s/AKfycbx8q9tw9WotXTRKQNjnb6BzlkyHBzDSpmgCQwt3yNepze4wpAU/exec"
+
+module.exports = (robot) ->
+  robot.respond /Seminar/i, (res) ->
+    request res
+
+request = (res) ->
+  https.get url, (response) ->
+    redirUrl = response.headers.location
+    redir res, redirUrl
+
+# GoogleAppScriptでデプロイしており，対象URLにアクセスすると
+# status 302で戻ってきてリダイレクトしなくてはならない
+redir = (res, redirUrl) ->
+  https.get redirUrl, (response) ->
+    response.setEncoding 'utf8'
+    response.on 'data', (body) ->
+      json = JSON.parse(body)
+      createMsg res, json
+
+createMsg = (res, json) ->
+  msg = "本日のセミナー情報です\n" + json.title + "\n"
+  msg += "場所:" + json.place + "\n"
+  msg += "時間:" + json.start_time + "~" + json.end_time + "\n"
+  res.send msg


### PR DESCRIPTION
hubotに`seminar`と送ると，その日のセミナー情報が表示されるんだよ．

セミナー情報はGoogle App scriptで引っ張ってるよ

``` js
function doGet(p) {
  return ContentService.createTextOutput(getSeminarPlace(p)).setMimeType(ContentService.MimeType.JSON);
}


function getSeminarPlace(p) {
  var date = getDateFromParams(p)

  var calendar = CalendarApp.getCalendarById("カレンダーID");

  var events = calendar.getEventsForDay(date)

  for (var i = 0; i < events.length; i++) {
    if (events[i].getTitle().match(/Seminar/) != null) {
      return createResponse(events[i])
    }
  }
  return createJSON("", "", "", "")
}

//日付指定は今のとこ動かない
function getDateFromParams(p) {
  var date
  if (p.parameter != undefined && p.parameter.date != undefined
      && (date = new Date(p.parameter.date)) != undefined) {
   return date
  } else {
   return new Date() 
  }
}

function createResponse(event) {
  title = event.getTitle()
  place = event.getLocation()
  start = event.getStartTime().toLocaleTimeString().substring(0,5)
  end = event.getEndTime().toLocaleTimeString().substring(0,5)
  return createJSON(title, place, start, end)
}

function createJSON(title, place, start, end) {
  return JSON.stringify({ "title": title, "place": place, "start_time": start, "end_time": end })
}

```
